### PR TITLE
feat(ui): Implement trading mode switcher for Story 4.5

### DIFF
--- a/src/ultibot_ui/services/__init__.py
+++ b/src/ultibot_ui/services/__init__.py
@@ -1,8 +1,13 @@
 # src/ultibot_ui/services/__init__.py
 from .ui_market_data_service import UIMarketDataService
 from .ui_config_service import UIConfigService
+from .api_client import UltiBotAPIClient # Assuming this was missing or needs to be kept
+from .trading_mode_service import TradingMode, TradingModeService
 
 __all__ = [
     "UIMarketDataService",
-    "UIConfigService"
+    "UIConfigService",
+    "UltiBotAPIClient", # Assuming this was missing or needs to be kept
+    "TradingMode",
+    "TradingModeService",
 ]

--- a/src/ultibot_ui/services/trading_mode_service.py
+++ b/src/ultibot_ui/services/trading_mode_service.py
@@ -1,0 +1,75 @@
+import logging
+from enum import Enum, auto
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+logger = logging.getLogger(__name__)
+
+class TradingMode(Enum):
+    PAPER = auto()
+    REAL = auto()
+
+    def __str__(self):
+        return self.name.capitalize()
+
+class TradingModeService(QObject):
+    '''
+    Manages the global trading mode (Paper or Real) for the UI.
+    '''
+    mode_changed = pyqtSignal(TradingMode) # Signal to indicate mode change
+
+    def __init__(self, default_mode: TradingMode = TradingMode.PAPER):
+        super().__init__()
+        self._current_mode: TradingMode = default_mode
+        logger.info(f"TradingModeService initialized with mode: {self._current_mode}")
+
+    def get_current_mode(self) -> TradingMode:
+        '''
+        Returns the current trading mode.
+        '''
+        return self._current_mode
+
+    def set_mode(self, mode: TradingMode):
+        '''
+        Sets the trading mode and emits a signal if it changes.
+        '''
+        logger.debug(f"TradingModeService.set_mode called with {mode}. Current mode is {self._current_mode}")
+        if not isinstance(mode, TradingMode):
+            logger.error(f"Attempted to set invalid trading mode type: {type(mode)}. Value: {mode}")
+            raise ValueError("Mode must be an instance of TradingMode Enum")
+
+        if self._current_mode != mode:
+            self._current_mode = mode
+            logger.info(f"Trading mode changed to: {self._current_mode}")
+            self.mode_changed.emit(self._current_mode)
+        else:
+            logger.debug(f"Trading mode set to {mode}, but no change detected from current mode {self._current_mode}.")
+
+    def is_paper_mode(self) -> bool:
+        '''Returns True if current mode is Paper Trading.'''
+        return self._current_mode == TradingMode.PAPER
+
+    def is_real_mode(self) -> bool:
+        '''Returns True if current mode is Real Trading.'''
+        return self._current_mode == TradingMode.REAL
+
+if __name__ == '__main__':
+    # Example Usage (for testing purposes)
+    service = TradingModeService()
+
+    def on_mode_change(new_mode):
+        print(f"Mode changed via signal: {new_mode}")
+        print(f"Is paper: {service.is_paper_mode()}")
+        print(f"Is real: {service.is_real_mode()}")
+
+    service.mode_changed.connect(on_mode_change)
+
+    print(f"Initial mode: {service.get_current_mode()}")
+    service.set_mode(TradingMode.REAL)
+    service.set_mode(TradingMode.REAL) # No change
+    service.set_mode(TradingMode.PAPER)
+
+    try:
+        service.set_mode("invalid_mode_string")
+    except ValueError as e:
+        print(f"Error caught: {e}")

--- a/src/ultibot_ui/windows/dashboard_view.py
+++ b/src/ultibot_ui/windows/dashboard_view.py
@@ -20,9 +20,10 @@ from src.ultibot_backend.services.portfolio_service import PortfolioService
 from src.ultibot_backend.adapters.persistence_service import SupabasePersistenceService # Importar SupabasePersistenceService
 from src.ultibot_backend.services.notification_service import NotificationService # Importar NotificationService
 from src.ultibot_ui.widgets.notification_widget import NotificationWidget # Importar NotificationWidget
+from src.ultibot_ui.services import TradingModeService # Import TradingModeService
 
 class DashboardView(QWidget):
-    def __init__(self, user_id: UUID, market_data_service: MarketDataService, config_service: ConfigService, notification_service: NotificationService, persistence_service: SupabasePersistenceService, api_client: UltiBotAPIClient): # Añadir api_client
+    def __init__(self, user_id: UUID, market_data_service: MarketDataService, config_service: ConfigService, notification_service: NotificationService, persistence_service: SupabasePersistenceService, api_client: UltiBotAPIClient, trading_mode_service: TradingModeService): # Add trading_mode_service
         super().__init__()
         self.user_id = user_id
         self.market_data_service = market_data_service
@@ -30,6 +31,7 @@ class DashboardView(QWidget):
         self.notification_service = notification_service # Guardar la referencia al servicio de notificaciones
         self.persistence_service = persistence_service # Guardar la referencia al servicio de persistencia
         self.api_client = api_client # Guardar la referencia al cliente API
+        self.trading_mode_service = trading_mode_service # Store TradingModeService
         
         # Inicializar PortfolioService aquí, ya que DashboardView tiene sus dependencias
         self.portfolio_service = PortfolioService(self.market_data_service, self.persistence_service)
@@ -65,7 +67,10 @@ class DashboardView(QWidget):
         center_splitter.setChildrenCollapsible(False)
 
         # Panel Izquierdo: Estado del Portafolio (PortfolioWidget)
-        self.portfolio_widget = PortfolioWidget(self.user_id, self.portfolio_service)
+        self.portfolio_widget = PortfolioWidget(user_id=self.user_id, 
+                                                portfolio_service=self.portfolio_service, 
+                                                trading_mode_service=self.trading_mode_service, 
+                                                api_client=self.api_client)
         center_splitter.addWidget(self.portfolio_widget)
         
         # Iniciar las actualizaciones del portfolio_widget


### PR DESCRIPTION
Implements a global trading mode (Paper/Real) switching mechanism.

Key changes:
- Introduced `TradingModeService` to manage the currently active trading mode state (`PAPER` or `REAL`) and notify listeners of changes.
- Added a `QComboBox` to the `MainWindow` status bar, allowing you to select the desired trading mode.
- Modified `PortfolioWidget` to dynamically update its view based on the selected trading mode. It now shows only the relevant section (Paper or Real) at a time.
- Integrated `TradingModeService` through `MainWindow` and `DashboardView` to connect the UI switcher with `PortfolioWidget`.
- Added debug logging to assist in testing the new functionality.

This work addresses the core requirements of Story 4.5 for alternating views between paper and real trading contexts, focusing on the `PortfolioWidget` as the first component to adopt this. Other UI elements like order forms and history views can be adapted in the future using the new service.